### PR TITLE
Update gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,9 +5,8 @@ on:
     branches:
     - 'master'
   repository_dispatch:
-    types: [build_documentation] 
-  schedule:
-  - cron:  '0 2 * * *'
+    types: [build_documentation]
+  workflow_dispatch:
 
 jobs:
   docs:


### PR DESCRIPTION
This PR removes the scheduled workflow as there's a [timeout of 60 days][1], plus we don't really need it.

Also, a manual workflow is added.

cc @traversaro @drdanz 

[1]: https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/disabling-and-enabling-a-workflow